### PR TITLE
Uncaught TypeError causes break in some functionality without refresh

### DIFF
--- a/TabsOfAvabur.user.js
+++ b/TabsOfAvabur.user.js
@@ -1066,7 +1066,9 @@
     }
 
     function saveOptions() {
-        clearTimeout(SSN);
+        if (typeof SSN !== 'undefined' && SSN > 0) {
+          clearTimeout(SSN);
+        }
         let opts = JSON.stringify(options);
         localStorage.setItem("ToAOPTS", opts);
         $("#ToASettingsSaved").show();


### PR DESCRIPTION
This fix is related to edvordo/TabsOfAvabur#6 and is the nearest to the direct cause I could get without going deep and trying to find why SSN is getting unset. After 48 hours of testing I have not experienced any further crashes similar to this issue.

Incidents of Uncaught TypeError in saveOptions  are causing persistence to crash causing tabs to be unable to be switched without refresh. I was unable to find why SSN is being destroyed, but as the fix was more/less introducing a healthier operation with or without. I did not feel putting another let SSN = 0; was necessary since a few lines later it is set anyways. 

The Error (from chrome dev tools, so the line numbers aren't exact obviously): 

`Uncaught TypeError: Cannot convert undefined or null to object
    at saveOptions (VM436 userscript.html:1147)
    at savePersistentChannels (VM436 userscript.html:1698)
    at updateChannelList (VM436 userscript.html:423)
    at processMessage (VM436 userscript.html:1650)
    at MutationObserver.eval (VM436 userscript.html:1662)`

By the way I am Aeoiin in game, I tend to lurk and I am AFK pretty frequently but I'm always online and do check PMs.
