### PR TITLE
Fix mentions being invisible until you type

### DIFF
--- a/TabsOfAvabur.user.js
+++ b/TabsOfAvabur.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TabsOfAvabur
 // @namespace    Reltorakii.magic
-// @version      4.5.5
+// @version      4.5.7
 // @description  Tabs the channels it finds in chat, can be sorted, with notif for new messages
 // @author       Reltorakii
 // @match        http*://*.avabur.com/game*

--- a/TabsOfAvabur.user.js
+++ b/TabsOfAvabur.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TabsOfAvabur
 // @namespace    Reltorakii.magic
-// @version      4.5.4
+// @version      4.5.5
 // @description  Tabs the channels it finds in chat, can be sorted, with notif for new messages
 // @author       Reltorakii
 // @match        http*://*.avabur.com/game*
@@ -1298,7 +1298,8 @@
         if (!options.scriptSettings.profile_tooltip_mention) {
             return false;
         }
-        $("#chatMessage").append(" @" + $("#profileOptionTooltip").attr("data-username")).focus();
+        const currentMessage = $("#chatMessage").text()
+        $("#chatMessage").html(currentMessage + " @" + $("#profileOptionTooltip").attr("data-username")).focus();
         $("#profileOptionTooltip").hide();
     }
 


### PR DESCRIPTION
When you use the mention shortcut it appends the @username but it does not appear in the chat box until you type again. This changes that, though the pointer is still unforunately at the start of the mention instead of at the end.